### PR TITLE
Remove cert from KeepAlive call, unnecessary, and blocks those who ar…

### DIFF
--- a/betfairlightweight/__init__.py
+++ b/betfairlightweight/__init__.py
@@ -6,7 +6,7 @@ from .streaming import StreamListener
 from . import filters
 
 __title__ = 'betfairlightweight'
-__version__ = '1.5.5'
+__version__ = '1.5.6'
 __author__ = 'Liam Pauling'
 
 # Set default logging handler to avoid "No handler found" warnings.

--- a/betfairlightweight/endpoints/keepalive.py
+++ b/betfairlightweight/endpoints/keepalive.py
@@ -31,7 +31,7 @@ class KeepAlive(BaseEndpoint):
         session = session or self.client.session
         date_time_sent = datetime.datetime.utcnow()
         try:
-            response = session.post(self.url, headers=self.client.keep_alive_headers, cert=self.client.cert)
+            response = session.post(self.url, headers=self.client.keep_alive_headers)
         except ConnectionError:
             raise APIError(None, exception='ConnectionError')
         except Exception as e:

--- a/tests/unit/test_keepalive.py
+++ b/tests/unit/test_keepalive.py
@@ -25,23 +25,21 @@ class KeepAliveTest(unittest.TestCase):
         assert isinstance(response, KeepAliveResource)
         assert self.keep_alive.client.session_token == mock.json().get('token')
 
-    @mock.patch('betfairlightweight.baseclient.BaseClient.cert')
     @mock.patch('betfairlightweight.baseclient.BaseClient.keep_alive_headers')
     @mock.patch('betfairlightweight.baseclient.requests.post')
-    def test_request(self, mock_post, mock_keep_alive_headers, mock_cert):
+    def test_request(self, mock_post, mock_keep_alive_headers):
         mock_response = create_mock_json('tests/resources/logout_success.json')
         mock_post.return_value = mock_response
 
         url = 'https://identitysso.betfair.com/api/keepAlive'
         response = self.keep_alive.request()
 
-        mock_post.assert_called_once_with(url, headers=mock_keep_alive_headers, cert=mock_cert)
+        mock_post.assert_called_once_with(url, headers=mock_keep_alive_headers)
         assert response[0] == mock_response.json()
 
-    @mock.patch('betfairlightweight.baseclient.BaseClient.cert')
     @mock.patch('betfairlightweight.baseclient.BaseClient.keep_alive_headers')
     @mock.patch('betfairlightweight.baseclient.requests.post')
-    def test_request_error(self, mock_post, mock_keep_alive_headers, mock_cert):
+    def test_request_error(self, mock_post, mock_keep_alive_headers):
         mock_post.side_effect = ValueError()
 
         with self.assertRaises(APIError):


### PR DESCRIPTION
…en't cert enabled (NJ Exchange).