### PR TITLE
Use a dict for login parameters

### DIFF
--- a/betfairlightweight/endpoints/login.py
+++ b/betfairlightweight/endpoints/login.py
@@ -62,4 +62,4 @@ class Login(BaseEndpoint):
 
     @property
     def data(self):
-        return 'username=%s&password=%s' % (self.client.username, self.client.password)
+        return {'username': self.client.username, 'password': self.client.password}

--- a/tests/unit/test_login.py
+++ b/tests/unit/test_login.py
@@ -35,7 +35,7 @@ class LoginTest(unittest.TestCase):
         url = 'https://identitysso.betfair.com/api/certlogin'
         response = self.login.request()
 
-        mock_post.assert_called_once_with(url, data='username=username&password=password',
+        mock_post.assert_called_once_with(url, data={'username': 'username', 'password': 'password'},
                                           headers=mock_login_headers, cert=mock_cert)
         assert response[0] == mock_response.json()
 
@@ -76,4 +76,4 @@ class LoginTest(unittest.TestCase):
         assert self.login.url == 'https://identitysso.betfair.com/api/certlogin'
 
     def test_data(self):
-        assert self.login.data == 'username=username&password=password'
+        assert self.login.data == {'username': 'username', 'password': 'password'}


### PR DESCRIPTION
By using a dict instead of a string, the requests library will URL encode the parameters which resolves issues with passwords which have special characters in them.

Closes #151 
