### PR TITLE
streaming: Stopping threads reading from the socket before the socker is closed

### DIFF
--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -39,7 +39,7 @@ class BetfairStream(object):
         self.host = self.HOSTS[host]
         self.receive_count = 0
         self.datetime_last_received = None
-
+        self.read_threads = []
         self._socket = None
         self._running = False
 
@@ -56,13 +56,19 @@ class BetfairStream(object):
             t = threading.Thread(name=self.description, target=self._read_loop)
             t.daemon = False
             t.start()
+            self.read_threads.append(t)
         else:
             self._read_loop()
 
     def stop(self):
         """Stops read loop and closes socket if it has been created.
         """
+
+        
         self._running = False
+        for read_thread in self.read_threads:
+            read_thread.join()
+
 
         if self._socket is None:
             return

--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -64,11 +64,11 @@ class BetfairStream(object):
         """Stops read loop and closes socket if it has been created.
         """
 
-        
+
         self._running = False
         for read_thread in self.read_threads:
-            read_thread.join()
-
+            read_thread.join() #Leting the threads see that self.__running is false
+        self.read_thread =[] #Stop keeping track of the threads
 
         if self._socket is None:
             return

--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -67,8 +67,9 @@ class BetfairStream(object):
 
         self._running = False
         for read_thread in self.read_threads:
-            read_thread.join() #Leting the threads see that self.__running is false
-        self.read_thread =[] #Stop keeping track of the threads
+            read_thread.join() #Letting the threads see that self.__running is false
+        
+        self.read_threads =[] #Stop keeping track of the threads
 
         if self._socket is None:
             return

--- a/tests/unit/test_betfairstream.py
+++ b/tests/unit/test_betfairstream.py
@@ -39,6 +39,7 @@ class BetfairStreamTest(unittest.TestCase):
         assert self.betfair_stream.host == 'stream-api.betfair.com'
         assert self.betfair_stream.receive_count == 0
         assert self.betfair_stream.datetime_last_received is None
+        assert self.betfair_stream.read_threads is []
 
         assert self.betfair_stream._socket is None
         assert self.betfair_stream._running is False
@@ -76,6 +77,7 @@ class BetfairStreamTest(unittest.TestCase):
         self.betfair_stream.stop()
         assert self.betfair_stream._running is False
         assert self.betfair_stream._socket is None
+        assert self.betfair_stream.read_threads is []
 
     @mock.patch('betfairlightweight.streaming.betfairstream.BetfairStream._send')
     def test_authenticate(self, mock_send):

--- a/tests/unit/test_betfairstream.py
+++ b/tests/unit/test_betfairstream.py
@@ -39,7 +39,7 @@ class BetfairStreamTest(unittest.TestCase):
         assert self.betfair_stream.host == 'stream-api.betfair.com'
         assert self.betfair_stream.receive_count == 0
         assert self.betfair_stream.datetime_last_received is None
-        assert self.betfair_stream.read_threads is []
+        assert self.betfair_stream.read_threads == []
 
         assert self.betfair_stream._socket is None
         assert self.betfair_stream._running is False
@@ -77,7 +77,7 @@ class BetfairStreamTest(unittest.TestCase):
         self.betfair_stream.stop()
         assert self.betfair_stream._running is False
         assert self.betfair_stream._socket is None
-        assert self.betfair_stream.read_threads is []
+        assert self.betfair_stream.read_threads == []
 
     @mock.patch('betfairlightweight.streaming.betfairstream.BetfairStream._send')
     def test_authenticate(self, mock_send):


### PR DESCRIPTION
Keeping track of the read threads, and joining them before the socket is closed so they no longer try to read from a closed socket and throw an error.