### PR TITLE
Fix bug when img rc contains multiple entries for the same selection

### DIFF
--- a/betfairlightweight/streaming/cache.py
+++ b/betfairlightweight/streaming/cache.py
@@ -143,15 +143,17 @@ class MarketBookCache(BaseResource):
         if 'marketDefinition' not in kwargs:
             raise CacheError('"EX_MARKET_DEF" must be requested to use cache')
         self.market_definition = kwargs['marketDefinition']
-        self.runners = [RunnerBook(**i) for i in kwargs.get('rc', [])]
 
+        self.runners = []
         self.runner_dict = {}
         self.market_definition_runner_dict = {}
         self._update_runner_dict()
         self._update_market_definition_runner_dict()
 
+        self.update_cache({'rc': kwargs.get('rc', [])}, self.publish_time)
+
     def update_cache(self, market_change, publish_time):
-        self._datetime_updated = self.strip_datetime(publish_time)
+        self._datetime_updated = self.strip_datetime(publish_time) or self._datetime_updated
         self.publish_time = publish_time
 
         if 'marketDefinition' in market_change:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -185,6 +185,15 @@ class TestMarketBookCache(unittest.TestCase):
         self.market_book_cache._update_runner_dict()
         assert self.market_book_cache.runner_dict == {(123, 1.25): a, (456, -0.25): b}
 
+    def test_init_multiple_rc(self):
+        # Initialize data with multiple rc entries for the same selection
+        data = {'marketDefinition': {'runners': {}}}
+        data['rc'] = [{'atb': [[1.01, 200]], 'id': 13536143}, {'atl': [[1000.0, 200]], 'id': 13536143}]
+
+        market_book_cache = MarketBookCache(**data)
+
+        assert len(market_book_cache.runners) == len(market_book_cache.runner_dict)
+
 
 class TestRunnerBook(unittest.TestCase):
 


### PR DESCRIPTION
I was playing around with some historical data and ran across a bug where the `rc` in an `img` update contained multiple objects/entries for the same selection. It looked something like:

```
{..."rc":[{"atb":[[1.01,200],[1.03,11.52],[1.02,22.98],[1.13,15.38]],"id":23537142},{"spn":"Infinity","spf":"NaN","id":23537142},...],"con":true,"img":true...}
```

This caused in issue where multiple `RunnerBook` objects were created and pushed into `MarketBookCache.runners` for the same runner. The `runner_dict` would have the correct number of selections since it was keyed off of the `id`, but lost data since it pointed to a single one of the `RunnerBook` objects for the selection that only contained part of the image.

I'm not very familiar with java, but in the reference implementation of the cache, found in the following, it looks like they don't treat an image update differently than a non-image update, where as `betfairlightweight` was:

https://github.com/betfair/stream-api-sample-code/blob/master/java/client/src/main/java/com/betfair/esa/client/cache/market/Market.java#L39

Also, I'm not sure that the comment in the following line is correct, since it appears as if historic data can have the `img` key:

https://github.com/liampauling/betfair/blob/master/betfairlightweight/streaming/stream.py#L124

The change I made treats an image update (re-initialization of a `MarketBookCache`) the same as a regular update with regard to runner changes (`rc`) by calling `update_cache` on the img data. I also added a unit test to cover the scenario. Please let me know if this looks reasonable to you and I'm happy to make any further changes necessary.