### PR TITLE
Add requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE README.md
+include LICENSE README.md requirements.txt
 graft tests
 
 global-exclude *.py[co] .DS_Store


### PR DESCRIPTION
Given the new way that the `setup.py` reads the dependencies from `requirements.txt`, the latter file needs to be included in the source distribution if one is to install from source. 