### PR TITLE
Assigning return value when none is provided

### DIFF
--- a/betfairlightweight/streaming/listener.py
+++ b/betfairlightweight/streaming/listener.py
@@ -24,7 +24,7 @@ class BaseListener:
             )
         self.stream_unique_id = unique_id
         self.stream_type = operation
-        self.stream = self._add_stream(unique_id, operation)
+        self._add_stream(unique_id, operation)
 
     def on_data(self, raw_data: str) -> None:
         logger.info(raw_data)


### PR DESCRIPTION
The _add_stream() function doesn't return a value, so it doesn't make sense to assign the (non) response to the stream class variable. It doesn't appear to cause problems, but it's easy to see how it could cause one of those subtle, difficult to track down bugs.