### PR TITLE
filters.py time_range: accept datetime arguments

### DIFF
--- a/betfairlightweight/filters.py
+++ b/betfairlightweight/filters.py
@@ -82,13 +82,13 @@ def time_range(
         if isinstance(from_, datetime.datetime):
             from_ = from_.isoformat()
         elif not isinstance(from_, str):
-            raise TypeError("from_ must be str or datetime (not date)")
+            raise TypeError("The 'from_' value must be string or datetime (not date)")
 
     if to != None:
         if isinstance(to, datetime.datetime):
             to = to.isoformat()
-        elif not isinstance(from_, str):
-            raise TypeError("to must be str or datetime (not date)")
+        elif not isinstance(to, str):
+            raise TypeError("The 'to' value must be string or datetime (not date)")
 
     args = locals().copy()
     return {k.replace("_", ""): v for k, v in args.items()}

--- a/betfairlightweight/filters.py
+++ b/betfairlightweight/filters.py
@@ -1,3 +1,5 @@
+import datetime
+from typing import Union
 from .utils import to_camel_case
 
 from .resources import bettingresources
@@ -65,13 +67,31 @@ def streaming_order_filter(
     return {to_camel_case(k): v for k, v in args.items() if v is not None}
 
 
-def time_range(from_: str = None, to: str = None) -> dict:  # todo datetime conversion
+def time_range(
+    from_: Union[str, datetime.datetime] = None,
+    to: Union[str, datetime.datetime] = None,
+) -> dict:
     """
-    :param str from_:
-    :param str to:
+    :param Union[str, datetime.datetime] from_:
+    :param Union[str, datetime.datetime] to:
 
     :return: dict
     """
+
+    if isinstance(from_, datetime.datetime):
+        from_ = from_.isoformat()
+    elif isinstance(from_, datetime.date):
+        from_ = None
+    else:
+        pass
+
+    if isinstance(to, datetime.datetime):
+        to = to.isoformat()
+    elif isinstance(to, datetime.date):
+        to = None
+    else:
+        pass
+
     args = locals().copy()
     return {k.replace("_", ""): v for k, v in args.items()}
 

--- a/betfairlightweight/filters.py
+++ b/betfairlightweight/filters.py
@@ -78,19 +78,17 @@ def time_range(
     :return: dict
     """
 
-    if isinstance(from_, datetime.datetime):
-        from_ = from_.isoformat()
-    elif isinstance(from_, datetime.date):
-        from_ = None
-    else:
-        pass
+    if from_ != None:
+        if isinstance(from_, datetime.datetime):
+            from_ = from_.isoformat()
+        elif not isinstance(from_, str):
+            raise TypeError("from_ must be str or datetime (not date)")
 
-    if isinstance(to, datetime.datetime):
-        to = to.isoformat()
-    elif isinstance(to, datetime.date):
-        to = None
-    else:
-        pass
+    if to != None:
+        if isinstance(to, datetime.datetime):
+            to = to.isoformat()
+        elif not isinstance(from_, str):
+            raise TypeError("to must be str or datetime (not date)")
 
     args = locals().copy()
     return {k.replace("_", ""): v for k, v in args.items()}

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -46,10 +46,13 @@ class FilterTest(unittest.TestCase):
         dt1 = datetime.datetime.now()
         dt2 = datetime.datetime.now() + datetime.timedelta(days=1)
 
-        response = time_range()
-        assert response == {"from": None, "to": None}
+        with self.assertRaises(TypeError):
+            time_range(from_=dt1.date(), to=dt2.date())
 
-        response = time_range(from_=dt1.date(), to=dt2.date())
+        with self.assertRaises(TypeError):
+            time_range(from_=123, to=456)
+
+        response = time_range()
         assert response == {"from": None, "to": None}
 
         response = time_range(from_=dt1, to=dt2)

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -46,11 +46,18 @@ class FilterTest(unittest.TestCase):
         dt1 = datetime.datetime.now()
         dt2 = datetime.datetime.now() + datetime.timedelta(days=1)
 
-        with self.assertRaises(TypeError):
-            time_range(from_=dt1.date(), to=dt2.date())
+        cases = (
+            (dt1.date(), None),
+            (None, dt1.date()),
+            (123, None),
+            (None, 456),
+        )
 
-        with self.assertRaises(TypeError):
-            time_range(from_=123, to=456)
+        for case in cases:
+            from_ = case[0]
+            to = case[1]
+            with self.assertRaises(TypeError):
+                time_range(from_=from_, to=to)
 
         response = time_range()
         assert response == {"from": None, "to": None}

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 
 from betfairlightweight.filters import (
@@ -42,8 +43,17 @@ class FilterTest(unittest.TestCase):
         assert response == {"includeOverallPosition": True}
 
     def test_time_range(self):
+        dt1 = datetime.datetime.now()
+        dt2 = datetime.datetime.now() + datetime.timedelta(days=1)
+
         response = time_range()
         assert response == {"from": None, "to": None}
+
+        response = time_range(from_=dt1.date(), to=dt2.date())
+        assert response == {"from": None, "to": None}
+
+        response = time_range(from_=dt1, to=dt2)
+        assert response == {"from": dt1.isoformat(), "to": dt2.isoformat()}
 
         response = time_range(from_="123", to="456")
         assert response == {"from": "123", "to": "456"}


### PR DESCRIPTION
This change makes filters.py time_range() accept datetime arguments, while still allowing string parameters as it's been so far.