### PR TITLE
closes #283

### DIFF
--- a/betfairlightweight/streaming/listener.py
+++ b/betfairlightweight/streaming/listener.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseListener:
-    def __init__(self, max_latency: float = 0.5):
+    def __init__(self, max_latency: Optional[float] = 0.5):
         self.max_latency = max_latency
 
         self.connection_id = None
@@ -80,7 +80,7 @@ class StreamListener(BaseListener):
     def __init__(
         self,
         output_queue: queue.Queue = None,
-        max_latency: float = 0.5,
+        max_latency: Optional[float] = 0.5,
         lightweight: bool = False,
     ):
         """

--- a/betfairlightweight/streaming/stream.py
+++ b/betfairlightweight/streaming/stream.py
@@ -52,7 +52,7 @@ class BaseStream:
 
         publish_time = data["pt"]
         latency = self._calc_latency(publish_time)
-        if latency > self._max_latency:
+        if self._max_latency and latency > self._max_latency:
             logger.warning("[Stream: %s]: Latency high: %s" % (self.unique_id, latency))
 
         if self._lookup in data:

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -227,3 +227,6 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 ```
+
+!!! tip
+    By default `max_latency` is set to 0.5, this means a warning will be logged if the latency between the publishTime and your machines time is greater than this number. Often you will need to check that your clock is up to date, however this can be removed by setting `max_latency=None` when initializing the listener.

--- a/examples/examplestreaminghistorical.py
+++ b/examples/examplestreaminghistorical.py
@@ -59,7 +59,7 @@ class HistoricalListener(StreamListener):
 
 
 # create listener
-listener = HistoricalListener(max_latency=1e100)
+listener = HistoricalListener(max_latency=None)
 
 # create historical stream, update directory to file location
 stream = trading.streaming.create_historical_stream(

--- a/tests/unit/test_stream.py
+++ b/tests/unit/test_stream.py
@@ -58,6 +58,22 @@ class BaseStreamTest(unittest.TestCase):
         mock_calc_latency.return_value = 10
         self.stream.on_update(mock_response.json())
 
+    @mock.patch("betfairlightweight.streaming.stream.BaseStream._process")
+    @mock.patch(
+        "betfairlightweight.streaming.stream.BaseStream._calc_latency", return_value=0.1
+    )
+    @mock.patch("betfairlightweight.streaming.stream.BaseStream._update_clk")
+    def test_on_update_no_latency(
+        self, mock_update_clk, mock_calc_latency, mock_process
+    ):
+        data = {"pt": 12345, "mc": "trainer"}
+        self.listener.max_latency = None
+        self.stream.on_update(data)
+
+        mock_update_clk.assert_called_with(data)
+        mock_calc_latency.assert_called_with(data.get("pt"))
+        mock_process.assert_called_with(data.get("mc"), data.get("pt"))
+
     def test_clear_cache(self):
         self.stream._caches = {1: "abc"}
         self.stream.clear_cache()


### PR DESCRIPTION
max_latency can now be set to None to prevent warnings being displayed (annoying when backtesting as the latency is obviously very high)