### PR TITLE
lrucache added to strip_datetime, this function is used a lot, especa…

### DIFF
--- a/betfairlightweight/resources/baseresource.py
+++ b/betfairlightweight/resources/baseresource.py
@@ -1,3 +1,4 @@
+import functools
 import datetime
 from typing import Union, Optional
 
@@ -20,6 +21,7 @@ class BaseResource:
         return json.dumps(self._data)
 
     @staticmethod
+    @functools.lru_cache()
     def strip_datetime(value: Union[str, int]) -> Optional[datetime.datetime]:
         """
         Converts value to datetime if string or int.


### PR DESCRIPTION
…illy when lightweight is False and objects are created. Using a cache can dramatically reduce function calls:

base:           63,434,263 function calls (63430548 primitive calls) in 52.407 seconds
                1,723,088    0.986    0.000    1.962    0.000 /betfairlightweight/resources/baseresource.py:22(strip_datetime)
                58,113,867 function calls (58110152 primitive calls) in 47.575 seconds
                30,231    0.069    0.000    0.134    0.000 /betfairlightweight/resources/baseresource.py:23(strip_datetime)

eventId 29761984 marketId 1.170258201 used (30230 updates)