### PR TITLE
closes #318

### DIFF
--- a/betfairlightweight/streaming/cache.py
+++ b/betfairlightweight/streaming/cache.py
@@ -159,6 +159,7 @@ class MarketBookCache(BaseResource):
             raise CacheError('"EX_MARKET_DEF" must be requested to use cache')
         self.market_definition = kwargs["marketDefinition"]
 
+        self.streaming_update = None
         self.runners = []
         self.runner_dict = {}
         self.market_definition_runner_dict = {}
@@ -170,6 +171,7 @@ class MarketBookCache(BaseResource):
             self.strip_datetime(publish_time) or self._datetime_updated
         )
         self.publish_time = publish_time
+        self.streaming_update = market_change
 
         if "marketDefinition" in market_change:
             self.market_definition = market_change["marketDefinition"]
@@ -213,11 +215,11 @@ class MarketBookCache(BaseResource):
                     self._update_runner_dict()
 
     def create_resource(
-        self, unique_id: int, streaming_update: dict, lightweight: bool
+        self, unique_id: int, lightweight: bool
     ) -> Union[dict, MarketBook]:
         data = self.serialise
         data["streaming_unique_id"] = unique_id
-        data["streaming_update"] = streaming_update
+        data["streaming_update"] = self.streaming_update
         if lightweight:
             return data
         else:
@@ -408,11 +410,13 @@ class OrderBookCache(BaseResource):
         self.publish_time = kwargs.get("publish_time")
         self.market_id = kwargs.get("id")
         self.closed = kwargs.get("closed")
+        self.streaming_update = None
         self.runners = []
 
     def update_cache(self, order_book: dict, publish_time: int) -> None:
         self._datetime_updated = self.strip_datetime(publish_time)
         self.publish_time = publish_time
+        self.streaming_update = order_book
         if "closed" in order_book:
             self.closed = order_book["closed"]
 
@@ -431,11 +435,11 @@ class OrderBookCache(BaseResource):
                 self.runners.append(OrderBookRunner(**order_changes))
 
     def create_resource(
-        self, unique_id: int, streaming_update: dict, lightweight: bool
+        self, unique_id: int, lightweight: bool
     ) -> Union[dict, CurrentOrders]:
         data = self.serialise
         data["streaming_unique_id"] = unique_id
-        data["streaming_update"] = streaming_update
+        data["streaming_update"] = self.streaming_update
         if lightweight:
             return data
         else:

--- a/betfairlightweight/streaming/stream.py
+++ b/betfairlightweight/streaming/stream.py
@@ -63,7 +63,7 @@ class BaseStream:
 
     def snap(self, market_ids: list = None) -> list:
         return [
-            cache.create_resource(self.unique_id, None, self._lightweight)
+            cache.create_resource(self.unique_id, self._lightweight)
             for cache in list(self._caches.values())
             if market_ids is None or cache.market_id in market_ids
         ]
@@ -149,9 +149,7 @@ class MarketStream(BaseStream):
             self._updates_processed += 1
 
             output_market_book.append(
-                market_book_cache.create_resource(
-                    self.unique_id, market_book, self._lightweight
-                )
+                market_book_cache.create_resource(self.unique_id, self._lightweight)
             )
         self.on_process(output_market_book)
 
@@ -180,8 +178,6 @@ class OrderStream(BaseStream):
             self._updates_processed += 1
 
             output_order_book.append(
-                order_book_cache.create_resource(
-                    self.unique_id, order_book, self._lightweight
-                )
+                order_book_cache.create_resource(self.unique_id, self._lightweight)
             )
         self.on_process(output_order_book)

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -142,6 +142,7 @@ class TestMarketBookCache(unittest.TestCase):
             assert self.market_book_cache.market_definition == book.get(
                 "marketDefinition"
             )
+            self.assertEqual(self.market_book_cache.streaming_update, book)
 
     @mock.patch("betfairlightweight.streaming.cache.MarketBookCache.strip_datetime")
     def test_update_cache_tv(self, mock_strip_datetime):
@@ -153,6 +154,7 @@ class TestMarketBookCache(unittest.TestCase):
             self.market_book_cache.update_cache(book, publish_time)
             mock_strip_datetime.assert_called_with(publish_time)
             assert self.market_book_cache.total_matched == book.get("tv")
+            self.assertEqual(self.market_book_cache.streaming_update, book)
 
     # @mock.patch('betfairlightweight.resources.streamingresources.MarketBookCache.strip_datetime')
     # def test_update_cache_rc(self, mock_strip_datetime):
@@ -177,14 +179,14 @@ class TestMarketBookCache(unittest.TestCase):
         self, mock_market_book, mock_market_definition, mock_serialise
     ):
         # lightweight
-        market_book = self.market_book_cache.create_resource(1234, {"test"}, True)
+        market_book = self.market_book_cache.create_resource(1234, True)
         assert market_book == {
-            "streaming_update": {"test"},
+            "streaming_update": self.market_book_cache.streaming_update,
             "streaming_unique_id": 1234,
         }
         assert market_book == mock_serialise()
         # not lightweight
-        market_book = self.market_book_cache.create_resource(1234, {}, False)
+        market_book = self.market_book_cache.create_resource(1234, False)
         assert market_book == mock_market_book()
 
     def test_update_runner_dict(self):
@@ -317,6 +319,7 @@ class TestOrderBookCache(unittest.TestCase):
         )
         for order_book in mock_response.json().get("oc"):
             self.order_book_cache.update_cache(order_book, 1234)
+            self.assertEqual(self.order_book_cache.streaming_update, order_book)
 
         self.assertEqual(len(self.order_book_cache.runners), 5)
         self.assertEqual(len(self.order_book_cache.runner_dict), 5)
@@ -330,6 +333,7 @@ class TestOrderBookCache(unittest.TestCase):
         mock_response = create_mock_json("tests/resources/streaming_ocm_UPDATE.json")
         for order_book in mock_response.json().get("oc"):
             self.order_book_cache.update_cache(order_book, 1234)
+            self.assertEqual(self.order_book_cache.streaming_update, order_book)
 
             for order_changes in order_book.get("orc"):
                 # self.runner.matched_lays.update.assert_called_with(order_changes.get('ml', []))
@@ -344,6 +348,7 @@ class TestOrderBookCache(unittest.TestCase):
         mock_response = create_mock_json("tests/resources/streaming_ocm_UPDATE.json")
         for order_book in mock_response.json().get("oc"):
             self.order_book_cache.update_cache(order_book, 1234)
+            self.assertEqual(self.order_book_cache.streaming_update, order_book)
 
             for order_changes in order_book.get("orc"):
                 mock_order_book_runner.assert_called_with(**order_changes)
@@ -352,6 +357,7 @@ class TestOrderBookCache(unittest.TestCase):
         mock_response = create_mock_json("tests/resources/streaming_ocm_SUB_IMAGE.json")
         for order_book in mock_response.json().get("oc"):
             self.order_book_cache.update_cache(order_book, 1234)
+            self.assertEqual(self.order_book_cache.streaming_update, order_book)
         self.assertTrue(self.order_book_cache.closed)
 
     @mock.patch(
@@ -362,14 +368,14 @@ class TestOrderBookCache(unittest.TestCase):
     @mock.patch("betfairlightweight.streaming.cache.CurrentOrders")
     def test_create_resource(self, mock_current_orders, mock_serialise):
         # lightweight
-        current_orders = self.order_book_cache.create_resource(123, {"test"}, True)
+        current_orders = self.order_book_cache.create_resource(123, True)
         assert current_orders == mock_serialise()
         assert current_orders == {
-            "streaming_update": {"test"},
+            "streaming_update": self.order_book_cache.streaming_update,
             "streaming_unique_id": 123,
         }
         # not lightweight
-        current_orders = self.order_book_cache.create_resource(123, {}, False)
+        current_orders = self.order_book_cache.create_resource(123, False)
         assert current_orders == mock_current_orders()
 
     def test_runner_dict(self):


### PR DESCRIPTION
streaming_update stored and passed to create_resource response
before this change backtesting did not contain the latest streaming_update