### PR TITLE
Fix types for list_race_details

### DIFF
--- a/betfairlightweight/endpoints/scores.py
+++ b/betfairlightweight/endpoints/scores.py
@@ -15,18 +15,18 @@ class Scores(BaseEndpoint):
 
     def list_race_details(
         self,
-        meeting_ids: dict = None,
-        race_ids: str = None,
+        meeting_ids: list = None,
+        race_ids: list = None,
         session: requests.Session = None,
         lightweight: bool = None,
     ) -> Union[list, List[resources.RaceDetails]]:
         """
         Search for races to get their details.
 
-        :param dict meeting_ids: Optionally restricts the results to the specified meeting IDs.
+        :param list meeting_ids: Optionally restricts the results to the specified meeting IDs.
         The unique Id for the meeting equivalent to the eventId for that specific race as
         returned by listEvents
-        :param str race_ids: Optionally restricts the results to the specified race IDs. The
+        :param list race_ids: Optionally restricts the results to the specified race IDs. The
         unique Id for the race in the format meetingid.raceTime (hhmm). raceTime is in GMT
         :param requests.session session: Requests session object
         :param bool lightweight: If True will return dict not a resource


### PR DESCRIPTION
Looking at the API for `list_race_details`, it looks like the types are incorrect:

https://docs.developer.betfair.com/display/1smk3cen4v3lu3yomq5qye0ni/Race+Status+API#RaceStatusAPI-racedetails

I've changed the `meeting_ids` and `race_ids` both to lists instead of `dict` and `str` respectively to avoid confusion.  This isn't actually correct as they should be `Optional[list]` as they default to `None`, but I see that throughout the code, where the `Optional` is ignored. As a general note, when I run `mypy` on the code base there are a lot errors, including a lot of these '...has incompatible type "Optional[X]"; expected "X"'. 

