### PR TITLE
Fix broken build from source due to missing requirements-speed.txt file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
-include LICENSE README.md requirements.txt
+include LICENSE 
+include README.md 
+include requirements.txt 
+include requirements-speed.txt
+
 graft tests
 
 global-exclude *.py[co] .DS_Store


### PR DESCRIPTION
Currently if you try to build from source (i.e `python setup.py install`), the build fails because `requirements-speed.txt` is not in the source distribution. This fixes the issue. I also changed the format to have one include per line for readability and diff'ing clarity. 