### PR TITLE
historical generator has been accidentally calling create_resource tw…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,17 @@
 Release History
 ---------------
 
+2.10.1 (2020-11-24)
++++++++++++++++++++
+
+**Bug Fixes**
+
+- Historical generator fixed to only call `create_resource` once per call (huge speed improvement)
+
+**Dependencies**
+
+- requests upgraded to <2.26.0
+
 2.10.0 (2020-11-02)
 +++++++++++++++++++
 

--- a/betfairlightweight/__version__.py
+++ b/betfairlightweight/__version__.py
@@ -1,6 +1,6 @@
 __title__ = "betfairlightweight"
 __description__ = "Lightweight python wrapper for Betfair API-NG"
 __url__ = "https://github.com/liampauling/betfair"
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 __author__ = "Liam Pauling"
 __license__ = "MIT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests<2.25.0
+requests<2.26.0

--- a/tests/resources/streaming_ocm_EMPTY_IMAGE.json
+++ b/tests/resources/streaming_ocm_EMPTY_IMAGE.json
@@ -1,0 +1,1 @@
+{"op":"ocm","id":2,"clk":"AAgAAAAAAAAAAA==","pt":1604418055629,"oc":[{"accountId":1234567,"fullImage":true,"id":"1.161613698"}]}


### PR DESCRIPTION
…ice, once on on_process() and once on snap()

Refactor to only call during on_process if there is queue
Timings:
  before: 44734 calls    1.381s    0.000   48.707s
  after: 22367 calls    0.752s    0.000   26.373s

empty image test added