### PR TITLE
Use single file (.pem) certificate.

### DIFF
--- a/betfairlightweight/apiclient.py
+++ b/betfairlightweight/apiclient.py
@@ -1,3 +1,5 @@
+from typing import Union, Tuple
+
 import requests
 
 from .baseclient import BaseClient
@@ -12,7 +14,7 @@ class APIClient(BaseClient):
         app_key: str = None,
         certs: str = None,
         locale: str = None,
-        cert_files: list = None,
+        cert_files: Union[Tuple[str], str, None] = None,
         lightweight: bool = False,
         session: requests.Session = None,
     ):
@@ -24,7 +26,8 @@ class APIClient(BaseClient):
         :param str app_key: App Key for account, if None will look in .bashprofile
         :param str certs: Directory for certificates, if None will look in /certs
         :param str locale: Exchange to be used, defaults to international (.com) exchange
-        :param list cert_files: Certificate and key files. If None will use `self.certs`
+        :param list cert_files: if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') path pair. If None will use `self.certs`
         :param bool lightweight: If True endpoints will return dict not a resource (22x faster)
         :param requests.Session session: Pass requests session object, defaults to a new request each request
         """

--- a/betfairlightweight/baseclient.py
+++ b/betfairlightweight/baseclient.py
@@ -1,5 +1,7 @@
 import os
 import time
+from typing import Union, Tuple
+
 import requests
 import collections
 
@@ -54,7 +56,7 @@ class BaseClient:
         app_key: str = None,
         certs: str = None,
         locale: str = None,
-        cert_files: list = None,
+        cert_files: Union[Tuple[str], str, None] = None,
         lightweight: bool = False,
         session: requests.Session = None,
     ):
@@ -66,7 +68,8 @@ class BaseClient:
         :param str app_key: App Key for account, if None will look in .bashprofile
         :param str certs: Directory for certificates, if None will look in /certs
         :param str locale: Exchange to be used, defaults to international (.com) exchange
-        :param list cert_files: Certificate and key files. If None will use `self.certs`
+        :param list cert_files: if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') path pair. If None will use `self.certs`
         :param bool lightweight: If True endpoints will return dict not a resource (22x faster)
         :param requests.Session session: Pass requests session object, defaults to a new request each request
         """
@@ -144,12 +147,12 @@ class BaseClient:
             return False
 
     @property
-    def cert(self) -> list:
+    def cert(self) -> Union[Tuple[str], str]:
         """
         The betfair certificates, by default it looks for the
         certificates in /certs/.
 
-        :return: Path of cert files
+        :return: Tuple of cert files path or single path.
         :rtype: str
         """
         if self.cert_files is not None:
@@ -162,20 +165,22 @@ class BaseClient:
         except FileNotFoundError as e:
             raise CertsError(str(e))
 
-        cert = None
-        key = None
+        cert, key, pem = None, None, None
         for file in cert_path:
             ext = os.path.splitext(file)[-1]
             if ext in [".crt", ".cert"]:
                 cert = os.path.join(ssl_path, file)
             elif ext == ".key":
                 key = os.path.join(ssl_path, file)
-        if cert is None or key is None:
-            raise CertsError(
-                "Certificates not found in directory: '%s' (make sure .crt and .key file is present)"
-                % ssl_path
-            )
-        return [cert, key]
+            elif ext == ".pem":
+                pem = os.path.join(ssl_path, file)
+        if cert and key:
+            return (cert, key)
+        if pem:
+            return pem
+        msg = "Certificates not found in directory: '%s'" % ssl_path
+        hint = " (make sure .crt and .key pair or a single .pem is present)"
+        raise CertsError(msg + hint)
 
     @property
     def login_headers(self) -> dict:

--- a/tests/unit/test_baseclient.py
+++ b/tests/unit/test_baseclient.py
@@ -203,9 +203,7 @@ class BaseClientRelativePathTest(unittest.TestCase):
 
     @mock.patch("betfairlightweight.baseclient.os.listdir")
     def test_client_single_file_cert_mocked(self, mock_listdir):
-        mock_listdir.return_value = normpaths(
-            [".DS_Store", "client-2048.pem"]
-        )
+        mock_listdir.return_value = normpaths([".DS_Store", "client-2048.pem"])
         assert self.client.cert == os.path.normpath("../fail/client-2048.pem")
 
     @mock.patch("betfairlightweight.baseclient.os.listdir")


### PR DESCRIPTION
Propagate up to BaseClient and APIClient the ability to use single file certificate (a '.pem' file, containing the private key and the certificate). Keep and prefer the existing crt/key file pair, but use tuple instead of list as keep more similar as used in the requests library.