### PR TITLE
Add HISTORY.rst to MANIFEST.in to fix broken release test

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE
 include README.md 
 include requirements.txt 
 include requirements-speed.txt
+include HISTORY.rst
 
 graft tests
 


### PR DESCRIPTION
When attempting to run the test suite (`python -m unittest discover -s tests --verbose`) from the tarball on `pypi`, you get the following error:

```
======================================================================
ERROR: test_version (test_release.ReleaseTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/betfairlightweight_1644251545971/test_tmp/tests/test_release.py", line 10, in test_version
    with open("HISTORY.rst", "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'HISTORY.rst'
```

Since the `HISTORY.rst` is not included in the source distribution. I've added the file to the MANIFEST.in to address this. 